### PR TITLE
Correção de bug no cadastro de administrador

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   private
 
   def define_role
-    self.role = email.present? && email.match(/\A[\w.+-]+@punti.com/) ? :admin : :common
+    self.role = email.present? && email.match(/\A[\w.+-]+@punti.com\z/) ? :admin : :common
   end
 
   def check_phone_number_length


### PR DESCRIPTION
Esta PR corrige um bug que permitia que um usuário se tornasse administrador com um email terminado em punti.com.br. A partir de agora só se torna administrador um usuário com email terminado em punti.com.