### PR TITLE
Fix de redirecionamento para a view show, depois do create da campanha

### DIFF
--- a/app/controllers/promotional_campaigns_controller.rb
+++ b/app/controllers/promotional_campaigns_controller.rb
@@ -25,7 +25,7 @@ class PromotionalCampaignsController < ApplicationController
     @promotional_campaign = PromotionalCampaign.new(promotional_campaign_params)
 
     if @promotional_campaign.save
-      redirect_to promotional_campaigns_path, notice: t('.promotional_campaign_success')
+      redirect_to promotional_campaign_path(@promotional_campaign), notice: t('.promotional_campaign_success')
     else
       @companies = Company.all
       flash.now[:alert] = t('.promotional_campaign_fail')

--- a/spec/requests/user_register_promotional_campaign_request_spec.rb
+++ b/spec/requests/user_register_promotional_campaign_request_spec.rb
@@ -1,21 +1,6 @@
 require 'rails_helper'
 
 describe 'Usuário cadastra um campanha promocional' do
-  context 'enquanto admin' do
-    it 'com sucesso' do
-      admin = create(:user, email: 'admin@punti.com')
-      company = create(:company)
-
-      login_as(admin)
-      post(promotional_campaigns_path,
-           params: { promotional_campaign: { name: 'Natal', start_date: 1.week.from_now, end_date: 1.month.from_now,
-                                             company_id: company.id } })
-
-      expect(response).to have_http_status :found
-      expect(response).to redirect_to promotional_campaigns_path
-    end
-  end
-
   context 'enquanto visitante' do
     it 'mas não está logado e é direcionado para o login' do
       company = create(:company)

--- a/spec/system/admin_register_promotional_campaign_spec.rb
+++ b/spec/system/admin_register_promotional_campaign_spec.rb
@@ -17,6 +17,9 @@ describe 'Admin registra uma nova Campanha Promocional' do
 
     expect(page).to have_content 'Campanha Promocional'
     expect(page).to have_content 'Campanha Promocional cadastrada com sucesso'
+    expect(page).to have_content 'Campanha Verão 2023'
+    expect(page).to have_content 'Empresa Participante CodeCampus'
+    expect(page).to have_content 'Adicionar Categorias à Campanha'
   end
 
   it 'com dados incompletos' do


### PR DESCRIPTION
Nessa PR, foi feito o redirecionamento para a página de detalhe da campanha, depois de sua criação.
Para isso, foram ajustados os testes:
- de sistema qdo o admin registra uma campanha: ajustado para ver as informações do detalhe da campanha
- de request quando o admin registra uma campanha: que foi retirado por não ser preciso
