### PR TITLE
Fix do filtro dos produtos da Home, pelo menu de Categorias de Produto

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,10 @@
 class HomeController < ApplicationController
   def index
-    @products = Product.where(active: true).order(created_at: :desc).filter { |p| p.product_category.active? }
+    if params[:product_category].blank?
+      @products = Product.where(active: true).order(created_at: :desc).filter { |p| p.product_category.active? }
+    else
+      product_category = params[:product_category]
+      @products = Product.where(product_category_id: product_category, active: true).order(created_at: :desc)
+    end
   end
 end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -8,7 +8,7 @@
         </a>
         <ul class="dropdown-menu">
           <% @product_categories.each do |pc| %>
-            <li><a class="dropdown-item" href="#"><%= pc.name %></a></li>
+            <li><%= link_to(pc.name, root_path(product_category: pc.id), class: "dropdown-item")%></li>
           <% end %>
         </ul>
       </li>

--- a/app/views/products/search.html.erb
+++ b/app/views/products/search.html.erb
@@ -12,7 +12,7 @@
           <div class="card-body">
             <h5 class="card-title"><%= link_to product.name, product_path(product.id) %></h5>
             <p class="text-truncate mw-2"><%= product.description %></p>
-            <p><%= "#{show_price(product.price)} Pontos" %></p>
+            <p><%= "#{show_price(product.price)}" %></p>
           </div>
         </div>
       </div>

--- a/spec/system/user_view_products_filter_by_category_spec.rb
+++ b/spec/system/user_view_products_filter_by_category_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+describe 'Usuário vê os produtos da categoria escolhida no menu Categorias de Produtos' do
+  context 'como visitante' do
+    it 'e vê produtos ativos e não vê produtos desativados, nem vê o valor nem os pontos convertidos de cada produto' do
+      category = create(:product_category, name: 'Celular')
+      category_a = create(:product_category, name: 'Vestuário')
+      create(:product, name: 'Camiseta Azul', code: 'CMS123456', description: 'Uma camisa azul muito bonita',
+                       price: 8, product_category: category_a)
+      create(:product, name: 'Celular 1', code: 'AFG123456', description: 'Celular 1 AFG',
+                       price: 100, product_category: category)
+      create(:product, name: 'Celular 2', code: 'ABC123456', description: 'Celular 2 ABC',
+                       price: 100, product_category: category)
+      product = create(:product, name: 'Celular 3', code: 'XYZ456123', description: 'Celular 3 XYZ',
+                                 product_category: category)
+      product.update(active: false)
+
+      visit root_path
+      click_on 'Categorias de Produtos'
+      click_on 'Celular'
+
+      within('#recent_products.carousel') do
+        within('.card#AFG123456') do
+          expect(page).to have_link 'Celular 1'
+          expect(page).to have_content 'Celular 1 AFG'
+          expect(page).not_to have_content '2.000 Pontos'
+        end
+        within('.card#ABC123456') do
+          expect(page).to have_link 'Celular 2'
+          expect(page).to have_content 'Celular 2 ABC'
+          expect(page).not_to have_content '2.000 Pontos'
+        end
+      end
+      expect(page).not_to have_css '.card#CMS123456'
+      expect(page).not_to have_link 'Camiseta Azul'
+      expect(page).not_to have_content 'Uma camisa azul muito bonita'
+      expect(page).not_to have_css '.card#XYZ456123'
+      expect(page).not_to have_link 'Celular 3'
+      expect(page).not_to have_content 'Celular 3 XYZ'
+    end
+  end
+  context 'como usuário logado' do
+    it 'e vê produtos ativos e não vê produtos desativados, e vê o valor de cada produto convertido em pontos' do
+      user = create(:user)
+      create(:card_info, user:)
+      category = create(:product_category, name: 'Celular')
+      category_a = create(:product_category, name: 'Vestuário')
+      create(:product, name: 'Camiseta Azul', code: 'CMS123456', description: 'Uma camisa azul muito bonita',
+                       price: 8, product_category: category_a)
+      create(:product, name: 'Celular 1', code: 'AFG123456', description: 'Celular 1 AFG',
+                       price: 100, product_category: category)
+      create(:product, name: 'Celular 2', code: 'ABC123456', description: 'Celular 2 ABC',
+                       price: 100, product_category: category)
+      product = create(:product, name: 'Celular 3', code: 'XYZ456123', description: 'Celular 3 XYZ',
+                                 price: 100, product_category: category)
+      product.update(active: false)
+
+      login_as(user)
+      visit root_path
+      click_on 'Categorias de Produtos'
+      click_on 'Celular'
+
+      within('#recent_products.carousel') do
+        within('.card#AFG123456') do
+          expect(page).to have_link 'Celular 1'
+          expect(page).to have_content 'Celular 1 AFG'
+          expect(page).to have_content '2.000 Pontos'
+        end
+        within('.card#ABC123456') do
+          expect(page).to have_link 'Celular 2'
+          expect(page).to have_content 'Celular 2 ABC'
+          expect(page).to have_content '2.000 Pontos'
+        end
+      end
+      expect(page).not_to have_css '.card#CMS123456'
+      expect(page).not_to have_link 'Camiseta Azul'
+      expect(page).not_to have_content 'Uma camisa azul muito bonita'
+      expect(page).not_to have_css '.card#XYZ456123'
+      expect(page).not_to have_link 'Celular 3'
+      expect(page).not_to have_content 'Celular 3 XYZ'
+    end
+  end
+  context 'como administrador' do
+    it 'e vê produtos ativos e não vê produtos desativados, e vê o valor em Real(R$) de cada produto' do
+      admin = create(:user, email: 'admin@punti.com')
+      category = create(:product_category, name: 'Celular')
+      category_a = create(:product_category, name: 'Vestuário')
+      create(:product, name: 'Camiseta Azul', code: 'CMS123456', description: 'Uma camisa azul muito bonita',
+                       price: 8, product_category: category_a)
+      create(:product, name: 'Celular 1', code: 'AFG123456', description: 'Celular 1 AFG',
+                       price: 100, product_category: category)
+      create(:product, name: 'Celular 2', code: 'ABC123456', description: 'Celular 2 ABC',
+                       price: 100, product_category: category)
+      product = create(:product, name: 'Celular 3', code: 'XYZ456123', description: 'Celular 3 XYZ',
+                                 price: 100, product_category: category)
+      product.update(active: false)
+
+      login_as(admin)
+      visit root_path
+      click_on 'Categorias de Produtos'
+      click_on 'Celular'
+
+      within('#recent_products.carousel') do
+        within('.card#AFG123456') do
+          expect(page).to have_link 'Celular 1'
+          expect(page).to have_content 'Celular 1 AFG'
+          expect(page).to have_content 'R$ 100,00'
+        end
+        within('.card#ABC123456') do
+          expect(page).to have_link 'Celular 2'
+          expect(page).to have_content 'Celular 2 ABC'
+          expect(page).to have_content 'R$ 100,00'
+        end
+      end
+      expect(page).not_to have_css '.card#CMS123456'
+      expect(page).not_to have_link 'Camiseta Azul'
+      expect(page).not_to have_content 'Uma camisa azul muito bonita'
+      expect(page).not_to have_css '.card#XYZ456123'
+      expect(page).not_to have_link 'Celular 3'
+      expect(page).not_to have_content 'Celular 3 XYZ'
+    end
+  end
+end


### PR DESCRIPTION
Nessa PR, o visitante e os usuários comum e administrador poderão filtrar os produtos da Home, pelo menu de Categorias de Produto, escolhendo uma categoria.
Para isso, foram ajustadas partes do código que precisavam filtar os produtos por categoria, e criados testes para os três contextos:
- usuário vê produtos filtrados por categoria: como visitante, como usuário logado e como administrador

Obs. Durante a navegação, foi detectado um texto esquecido nos ajustes anteriores ("Pontos") no arquivo do resultado da busca do produto, e foi retirado.

![fix_cat_1](https://github.com/TreinaDev/LojaClubeTD10/assets/108029082/34a2ae09-4062-4090-902a-2b6ea978e7d7)
![fix_cat_2](https://github.com/TreinaDev/LojaClubeTD10/assets/108029082/ffbd39cd-1ada-4bc6-b3ef-4b6926937978)
