### PR TITLE
Mudanças de layout na tela de favoritos

### DIFF
--- a/app/controllers/customer_areas_controller.rb
+++ b/app/controllers/customer_areas_controller.rb
@@ -17,6 +17,9 @@ class CustomerAreasController < ApplicationController
     return unless user_signed_in?
 
     @user = current_user
-    @favorites = @user.favorites
+    @favorites_active = Favorite.joins(:product)
+                                .where(user: @user, products: { active: true })
+    @favorites_inactive = Favorite.joins(:product)
+                                  .where(user: @user, products: { active: false })
   end
 end

--- a/app/views/customer_areas/favorite_tab.html.erb
+++ b/app/views/customer_areas/favorite_tab.html.erb
@@ -19,7 +19,7 @@
                         <%= image_tag(asset_path('no_image.jpg'), alt:favorite.product.name, class:"card-img-top card-image")%>
                       <% end %>
                         <div class="card-body">
-                          <h5 class="card-title text-truncate"><%= link_to favorite.product.name, product_path(favorite.product.id) %>, <%= favorite.product.brand %></h5>
+                          <h5 class="card-title text-truncate"><%= link_to "#{favorite.product.name}, #{favorite.product.brand}", product_path(favorite.product.id) %></h5>
                           <p class="text-truncate mw-2"><%= favorite.product.description %></p>
                           <p><%= "#{show_price(favorite.product.price)}" if current_user&.card_info.present? || current_user&.admin? %></p>
                           <%= button_to 'Excluir', favorite_path(favorite), method: :delete, id: favorite.id, class: 'btn btn-outline-secondary btn-sm w-100' %>

--- a/app/views/customer_areas/favorite_tab.html.erb
+++ b/app/views/customer_areas/favorite_tab.html.erb
@@ -1,26 +1,71 @@
-<section>
-  <div class="container shadow p-2 mb-4 bg-body-tertiary rounded div-max-width">
-    <h2 class="text-center"><%= t(:product_favorites) %></h2>
-
-    <div class="container div-max-width p-2" >
-      <% if @favorites.any? %>
-        <table class="table table-striped table-hover  mt-4 ">
-          <tbody class="table-group-divider">
-            <% @favorites&.each do |favorite| %>
-              <tr class="text-center">
-                <td>
-                  <%= link_to product_path(favorite.product), class: 'link-secondary link-underline-opacity-0' do %>
-                    <%= favorite.product.name %>,  <%= favorite.product.brand %>
-                  <% end %>
-                </td>
-                <td><%= button_to 'Excluir', favorite_path(favorite), method: :delete, id: favorite.id, class: 'btn btn-outline-secondary btn-sm' %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      <% else %>
-        <p class="text-center">Você não selecionou nenhum produto como favorito</p>
+<div class="container-lg text-center pt-3 pe-4 ps-4">
+  <h1 class="mb-1 fw-bold"><%= t(:client_area) %></h1>
+  <div class="mb-4 mt-4">
+  
+    <%= render 'nav-tab' %>
+    <% if @favorites_active.any? || @favorites_inactive.any? %>
+      <% if @favorites_active.any? %>
+        <section class="text-start available d-flex flex-column">
+          <h4><%= t('.available_product') %></h4>
+          <% @favorites_active.each_slice(4).with_index do |product_favorite, index| %>
+            <div <%= carousel_item(index) %>>
+              <div class="d-flex flex-row gap-3 m-auto">
+                <% product_favorite.each do |favorite| %>
+                  <div>
+                    <div class="card shadow-sm p-3 mb-5 bg-white rounded product-card" id=<%= favorite.product.code %>>
+                      <% if favorite.product.product_images.attached? %>
+                        <%= image_tag(favorite.product.product_images[0], alt:favorite.product.name, class:"card-img-top card-image")%>
+                      <% else %>
+                        <%= image_tag(asset_path('no_image.jpg'), alt:favorite.product.name, class:"card-img-top card-image")%>
+                      <% end %>
+                        <div class="card-body">
+                          <h5 class="card-title text-truncate"><%= link_to favorite.product.name, product_path(favorite.product.id) %>, <%= favorite.product.brand %></h5>
+                          <p class="text-truncate mw-2"><%= favorite.product.description %></p>
+                          <p><%= "#{show_price(favorite.product.price)}" if current_user&.card_info.present? || current_user&.admin? %></p>
+                          <%= button_to 'Excluir', favorite_path(favorite), method: :delete, id: favorite.id, class: 'btn btn-outline-secondary btn-sm w-100' %>
+                        </div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </section>
       <% end %>
+
+      <% if @favorites_inactive.any? %>
+        <section class="text-start unavailable d-flex flex-column">
+          <h4><%= t('.unavailable_product.other') %></h4>
+          <% @favorites_inactive.each_slice(4).with_index do |product_favorite, index| %>
+            <div <%= carousel_item(index) %>>
+              <div class="d-flex flex-row gap-3 m-auto">
+                <% product_favorite.each do |favorite| %>
+                  <div>
+                    <div class="card shadow-sm p-3 mb-5 bg-white rounded product-card" id=<%= favorite.product.code %> title="<%=t('.unavailable_product.one')%>">
+                      <% if favorite.product.product_images.attached? %>
+                        <%= image_tag(favorite.product.product_images[0], alt:favorite.product.name, class:"card-img-top card-image")%>
+                      <% else %>
+                        <%= image_tag(asset_path('no_image.jpg'), alt:favorite.product.name, class:"card-img-top card-image")%>
+                      <% end %>
+                        <div class="card-body">
+                          <h5 class="card-title text-truncate"><%= favorite.product.name %>, <%= favorite.product.brand %></h5>
+                          <p class="text-truncate mw-2"><%= favorite.product.description %></p>
+                          <p><%= "#{show_price(favorite.product.price)}" if current_user&.card_info.present? || current_user&.admin? %></p>
+                          <%= button_to 'Excluir', favorite_path(favorite), method: :delete, id: favorite.id, class: 'btn btn-outline-secondary btn-sm w-100' %>
+                        </div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </section>
+      <% end %>
+    
+    <% else %>
+      <p class="text-center"><%= t('.no_favorites_selected') %></p>
+    <% end %>
     </div>
   </div>
-</section>
+</div>
+

--- a/app/views/customer_areas/index.html.erb
+++ b/app/views/customer_areas/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="mb-1 fw-bold"><%= t(:client_area) %></h1>
   <div class="mb-4 mt-4">
 
-  <%= render 'nav-tab' %>
+    <%= render 'nav-tab' %>
     
     <div class="col-lg col-sm-12 text-start fs-4">
       <div class="row">

--- a/config/locales/customer_area.pt-BR.yml
+++ b/config/locales/customer_area.pt-BR.yml
@@ -1,5 +1,11 @@
 pt-BR:
   customer_areas:
+    favorite_tab: 
+      available_product: Produtos disponíveis
+      unavailable_product:
+        one: Produto indisponível
+        other: Produtos indisponíveis
+      no_favorites_selected: Você não selecionou nenhum produto como favorito
     index:
       my_account: 'Minha Conta'
       my_orders: 'Meus Pedidos'

--- a/spec/system/user_view_favorite_list_spec.rb
+++ b/spec/system/user_view_favorite_list_spec.rb
@@ -24,8 +24,10 @@ describe 'Usuário visualiza lista de favoritos' do
     category = create(:product_category)
     product1 = create(:product, name: 'TV', code: 'HJK123456', brand: 'Samsung', product_category: category)
     product2 = create(:product, name: 'Iphone', code: 'ASD123456', brand: 'Apple', product_category: category)
-    product3 = create(:product, name: 'Smartwatch', code: 'ASD163426', brand: 'Apple', product_category: category, active: false)
-    product4 = create(:product, name: 'Mouse', code: 'ASD143486', brand: 'Logitech', product_category: category, active: false)
+    product3 = create(:product, name: 'Smartwatch', code: 'ASD163426', brand: 'Apple', product_category: category,
+                                active: false)
+    product4 = create(:product, name: 'Mouse', code: 'ASD143486', brand: 'Logitech', product_category: category,
+                                active: false)
 
     Favorite.create!(user:, product: product1)
     Favorite.create!(user:, product: product2)
@@ -47,7 +49,6 @@ describe 'Usuário visualiza lista de favoritos' do
       expect(page).to have_content 'Smartwatch, Apple'
       expect(page).to have_content 'Mouse, Logitech'
     end
- 
   end
 
   it 'na área do cliente e não existem produtos favoritos indisponíveis' do
@@ -76,8 +77,10 @@ describe 'Usuário visualiza lista de favoritos' do
     user = User.create!(name: 'matheus', email: 'matheus@mail.com', password: 'senha1234',
                         phone_number: '19998555544', cpf: '56685728701')
     category = create(:product_category)
-    product1 = create(:product, name: 'TV', code: 'HJK123456', brand: 'Samsung', product_category: category, active: false)
-    product2 = create(:product, name: 'Iphone', code: 'ASD123456', brand: 'Apple', product_category: category, active: false)
+    product1 = create(:product, name: 'TV', code: 'HJK123456', brand: 'Samsung',
+                                product_category: category, active: false)
+    product2 = create(:product, name: 'Iphone', code: 'ASD123456', brand: 'Apple',
+                                product_category: category, active: false)
 
     Favorite.create!(user:, product: product1)
     Favorite.create!(user:, product: product2)

--- a/spec/system/user_view_favorite_list_spec.rb
+++ b/spec/system/user_view_favorite_list_spec.rb
@@ -18,7 +18,39 @@ describe 'Usuário visualiza lista de favoritos' do
     expect(page).to have_content 'Administrador não tem acesso a essa página'
   end
 
-  it 'na área do cliente' do
+  it 'na área do cliente e existem produtos favoritos disponíveis e indisponíveis' do
+    user = User.create!(name: 'matheus', email: 'matheus@mail.com', password: 'senha1234',
+                        phone_number: '19998555544', cpf: '56685728701')
+    category = create(:product_category)
+    product1 = create(:product, name: 'TV', code: 'HJK123456', brand: 'Samsung', product_category: category)
+    product2 = create(:product, name: 'Iphone', code: 'ASD123456', brand: 'Apple', product_category: category)
+    product3 = create(:product, name: 'Smartwatch', code: 'ASD163426', brand: 'Apple', product_category: category, active: false)
+    product4 = create(:product, name: 'Mouse', code: 'ASD143486', brand: 'Logitech', product_category: category, active: false)
+
+    Favorite.create!(user:, product: product1)
+    Favorite.create!(user:, product: product2)
+    Favorite.create!(user:, product: product3)
+    Favorite.create!(user:, product: product4)
+
+    login_as user
+    visit customer_areas_path
+    click_on 'Produtos Favoritos'
+
+    expect(current_path).to eq favorite_tab_path
+    within '.available' do
+      expect(page).to have_content 'TV, Samsung'
+      expect(page).to have_content 'Iphone, Apple'
+    end
+    within '.unavailable' do
+      expect(page).not_to have_content 'TV, Samsung'
+      expect(page).not_to have_content 'Iphone, Apple'
+      expect(page).to have_content 'Smartwatch, Apple'
+      expect(page).to have_content 'Mouse, Logitech'
+    end
+ 
+  end
+
+  it 'na área do cliente e não existem produtos favoritos indisponíveis' do
     user = User.create!(name: 'matheus', email: 'matheus@mail.com', password: 'senha1234',
                         phone_number: '19998555544', cpf: '56685728701')
     category = create(:product_category)
@@ -33,8 +65,33 @@ describe 'Usuário visualiza lista de favoritos' do
     click_on 'Produtos Favoritos'
 
     expect(current_path).to eq favorite_tab_path
-    expect(page).to have_content 'TV, Samsung'
-    expect(page).to have_content 'Iphone, Apple'
+    within '.available' do
+      expect(page).to have_content 'TV, Samsung'
+      expect(page).to have_content 'Iphone, Apple'
+    end
+    expect(page).not_to have_content 'Produtos indisponíveis'
+  end
+
+  it 'na área do cliente e não existem produtos favoritos disponíveis' do
+    user = User.create!(name: 'matheus', email: 'matheus@mail.com', password: 'senha1234',
+                        phone_number: '19998555544', cpf: '56685728701')
+    category = create(:product_category)
+    product1 = create(:product, name: 'TV', code: 'HJK123456', brand: 'Samsung', product_category: category, active: false)
+    product2 = create(:product, name: 'Iphone', code: 'ASD123456', brand: 'Apple', product_category: category, active: false)
+
+    Favorite.create!(user:, product: product1)
+    Favorite.create!(user:, product: product2)
+
+    login_as user
+    visit customer_areas_path
+    click_on 'Produtos Favoritos'
+
+    expect(current_path).to eq favorite_tab_path
+    within '.unavailable' do
+      expect(page).to have_content 'TV, Samsung'
+      expect(page).to have_content 'Iphone, Apple'
+    end
+    expect(page).not_to have_content 'Produtos disponíveis'
   end
 
   it 'e não tem nenhum favorito selecionado' do


### PR DESCRIPTION
close #103
Foram feitas mudanças de layout na tela de favoritos da aplicação. Agora é exibido um card semelhante ao da tela inicial representando o produto favorito. Os produtos favoritados indisponíveis e os indisponíveis aparecem de maneira separada agora!  A página agora também se adequou ao padrão das outras telas da área do cliente. 
**_Antes:_**
![Screenshot_803](https://github.com/TreinaDev/LojaClubeTD10/assets/91296759/0e10d125-5625-4f31-8c52-d1dcea7e98b6)
_**Depois**_
![Screenshot_805](https://github.com/TreinaDev/LojaClubeTD10/assets/91296759/4a1cc320-4e4b-4c4a-8901-f4cb954bd4d8)
![Screenshot_806](https://github.com/TreinaDev/LojaClubeTD10/assets/91296759/8a0d6195-31fb-4030-9a86-7af969d7df60)
![Screenshot_807](https://github.com/TreinaDev/LojaClubeTD10/assets/91296759/f8f404b3-c6ab-4887-9ce6-ea8648ffc202)
![Screenshot_808](https://github.com/TreinaDev/LojaClubeTD10/assets/91296759/989d306a-fefc-433e-9014-83201a6d3873)
