### PR TITLE
Fix - endereço padrao

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -14,7 +14,7 @@ class AddressesController < ApplicationController
     @address = Address.new(addresses_params)
 
     if @address.save
-      status = ClientAddress.find_by(user: current_user).blank? ? true : false
+      status = ClientAddress.find_by(user: current_user).blank?
       ClientAddress.create(user: current_user, address: @address, default: status)
 
       return redirect_to client_addresses_path, notice: t('.success')

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -14,7 +14,8 @@ class AddressesController < ApplicationController
     @address = Address.new(addresses_params)
 
     if @address.save
-      ClientAddress.create(user: current_user, address: @address)
+      status = ClientAddress.find_by(user: current_user).blank? ? true : false
+      ClientAddress.create(user: current_user, address: @address, default: status)
 
       return redirect_to client_addresses_path, notice: t('.success')
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -6,28 +6,21 @@ class OrdersController < ApplicationController
   def index; end
   def show; end
 
-  def new
-    @order = Order.new
-  end
-
   def create
-    @order = Order.new(order_params, conversion_tax: current_user.card_info.conversion_tax, user_id: current_user.id)
-    save_order_model(@order)
-    flash.now[:alert] = t('.error')
-    render :new
-  end
-
-  def close_order
     return if card_not_present? || card_number_blank? || card_number_length_is_invalid?
 
-    order = build_order(@cart)
+    order = build_order(@cart, params[:order][:address_id])
     save_order_and_redirect(order)
   end
 
   private
 
-  def order_params
-    params.require(:order).permit(:total_value, :discount_amount, :final_value, :user_id, :conversion_tax)
+  def build_order(shopping_cart, address_id)
+    total_value = shopping_cart.total.round
+    discount = shopping_cart.total.round - total_with_discount_cart(shopping_cart)
+
+    Order.new(total_value:, discount_amount: discount, final_value: total_value - discount, user_id: current_user.id,
+              conversion_tax: current_user.card_info.conversion_tax, address_id:)
   end
 
   def transfer_products(order)
@@ -37,19 +30,14 @@ class OrdersController < ApplicationController
     end
   end
 
-  def build_order(shopping_cart)
-    total_value = shopping_cart.total.round
-    discount = shopping_cart.total.round - total_cart(shopping_cart)
-    Order.new(total_value:, discount_amount: discount, final_value: total_value - discount, user_id: current_user.id,
-              conversion_tax: current_user.card_info.conversion_tax)
-  end
-
   def send_payment_request(order)
     Faraday.post('http://localhost:4000/api/v1/payments') do |req|
-      req.headers['Content-Type'] = 'application/json'
-      req.body = { payment: { cpf: current_user.cpf, card_number: params[:card_number], total_value: order.total_value,
-                              descount_amount: order.discount_amount, final_value: order.final_value,
-                              payment_date: I18n.l(order.created_at.to_date), order_number: order.id } }.to_json
+      req.body = { payment: { cpf: current_user.cpf, card_number: params[:order][:card_number],
+                              total_value: order.total_value,
+                              descount_amount: order.discount_amount,
+                              final_value: order.final_value,
+                              payment_date: Time.zone.now.to_date, order_number: order.id } }.to_json
+      req.headers = { 'Content-Type': 'application/json' }
     end
   rescue Faraday::ConnectionFailed
     nil
@@ -65,40 +53,22 @@ class OrdersController < ApplicationController
     session[:cart_id] = nil
   end
 
-  def card_number_blank?
-    return false if params[:card_number].present?
-
-    redirect_to close_shopping_carts_path(@cart), alert: t('.card_number_empty')
-  end
-
-  def card_number_length_is_invalid?
-    return false if params[:card_number].length == 20
-
-    redirect_to close_shopping_carts_path(@cart), alert: t('.card_number_length_invalid')
-  end
-
-  def card_not_present?
-    return false if current_user.card_info.present?
-
-    redirect_to close_shopping_carts_path(@cart), alert: t('.card_not_present')
-  end
-
   def save_order_and_redirect(order)
     if order.save
       transfer_products(order)
       response = send_payment_request(order)
-      return redirect_to shopping_cart_path(@cart), alert: t('.connection_error') if response.nil?
+      return (order.destroy && redirect_to(shopping_cart_path(@cart), alert: t('.connection_error'))) if response.nil?
 
-      save_payment_code(order, response)
       response_redirect(response, order)
     else
-      redirect_to shopping_cart_path(@cart), alert: t('.error')
+      redirect_to shopping_cart_path(@cart), alert: (order.address.nil? ? t('.address_required') : t('.error'))
     end
   end
 
   def response_redirect(response, order)
     if response.status == 201
       destroy_cart
+      save_payment_code(order, response)
       redirect_to order_path(order.id), notice: t('.success')
     else
       redirect_to shopping_cart_path(@cart), alert: t('.error')
@@ -115,14 +85,25 @@ class OrdersController < ApplicationController
     @order = Order.find(params[:id])
   end
 
-  def save_order_model(order)
-    return unless order.save
-
-    transfer_products(order)
-    redirect_to root_path, notice: t('.success')
+  def total_with_discount_cart(cart)
+    cart.orderables.sum { |orderable| orderable.product.lowest_price(@company) * orderable.quantity }
   end
 
-  def total_cart(cart)
-    cart.orderables.sum { |orderable| orderable.product.lowest_price(@company) * orderable.quantity }
+  def card_number_blank?
+    return false if params[:order][:card_number].present?
+
+    redirect_to close_shopping_carts_path(@cart), alert: t('.card_number_empty')
+  end
+
+  def card_number_length_is_invalid?
+    return false if params[:order][:card_number].length == 20
+
+    redirect_to close_shopping_carts_path(@cart), alert: t('.card_number_length_invalid')
+  end
+
+  def card_not_present?
+    return false if current_user.card_info.present?
+
+    redirect_to close_shopping_carts_path(@cart), alert: t('.card_not_present')
   end
 end

--- a/app/controllers/shopping_carts_controller.rb
+++ b/app/controllers/shopping_carts_controller.rb
@@ -41,9 +41,8 @@ class ShoppingCartsController < ApplicationController
   end
 
   def close
-    @default_address = current_user.client_addresses
-                                   .find_by(default: true)
-                                   &.address
+    @order = Order.new(address: current_user.address_default)
+    @addresses = current_user.addresses
   end
 
   private

--- a/app/controllers/shopping_carts_controller.rb
+++ b/app/controllers/shopping_carts_controller.rb
@@ -42,7 +42,7 @@ class ShoppingCartsController < ApplicationController
 
   def close
     @order = Order.new
-    @addresses = current_user.addresses
+    @user_addresses = current_user.addresses
   end
 
   private

--- a/app/controllers/shopping_carts_controller.rb
+++ b/app/controllers/shopping_carts_controller.rb
@@ -41,7 +41,7 @@ class ShoppingCartsController < ApplicationController
   end
 
   def close
-    @order = Order.new(address: current_user.address_default)
+    @order = Order.new
     @addresses = current_user.addresses
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,7 +119,7 @@ module ApplicationHelper
     '</li>'.html_safe
   end
 
-  def total_cart(cart, company)
+  def total_with_discount_cart(cart, company)
     cart.orderables.sum { |orderable| orderable.product.lowest_price(company) * orderable.quantity }
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,4 +4,8 @@ class Address < ApplicationRecord
 
   validates :address, :number, :city, :state, :zipcode, presence: true
   validates :zipcode, length: { is: 8 }
+
+  def full_description
+    "#{address} (#{number}), #{city} - #{state}. CEP: #{zipcode}"
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,5 +1,6 @@
 class Order < ApplicationRecord
   belongs_to :user
+  belongs_to :address
   has_many :order_items, dependent: :destroy
   has_many :products, through: :order_items
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,8 +1,8 @@
 class Order < ApplicationRecord
   belongs_to :user
-  belongs_to :address
   has_many :order_items, dependent: :destroy
   has_many :products, through: :order_items
+  has_one :address, class_name: 'OrderAddress', dependent: :destroy
 
   validates :total_value, :final_value, numericality: { greater_than: 0 }
   validates :discount_amount, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,3 @@
+class OrderAddress < ApplicationRecord
+  belongs_to :order
+end

--- a/app/views/shopping_carts/_orderables.html.erb
+++ b/app/views/shopping_carts/_orderables.html.erb
@@ -39,7 +39,7 @@
           <% end %>
         </tbody>
       </table>
-      <p class="fw-bold">Total: <%= "#{show_price(total_cart(@shopping_cart, @company))} Pontos"%> </p>
+      <p class="fw-bold">Total: <%= "#{show_price(total_with_discount_cart(@shopping_cart, @company))} Pontos"%> </p>
       <div class="d-flex gap-3">
         <%= link_to "Continuar comprando", root_path, class:"btn btn-secondary" %>
         <%= button_to "Limpar carrinho", remove_all_shopping_carts_path, class:"btn btn-danger" %>

--- a/app/views/shopping_carts/close.html.erb
+++ b/app/views/shopping_carts/close.html.erb
@@ -69,16 +69,15 @@
         <p>Endereço de Entrega</p>
         <%= form_with model: @order , data: {turbo: false} do |f| %>
           <div>
-            <% @addresses.each do |address| %>
-              <div class="form-check">
-                <%= radio_button_tag :address_id,  address.id, address.full_description %>
-              </div>
-            <% end %>
-
-            <% if @addresses.empty? %>
-              <p> Nenhum endereço cadastrado </p>
-              <%= link_to 'Cadastrar Endereço', new_address_path, class: 'btn btn-secondary' %>
-            <% end %>
+          <div class="mb-3">
+              <% if @user_addresses.empty? %>
+                <p> Nenhum endereço cadastrado </p>
+                <%= link_to 'Cadastrar Endereço', new_address_path, class: 'btn btn-secondary' %>
+              <% else %>
+                <%= hidden_field_tag :address_id, current_user.address_default.id %>
+                <div><%= current_user.address_default.full_description %></div>
+              <% end %>
+            </div>
           </div>
 
           <div class="d-flex gap-3">

--- a/app/views/shopping_carts/close.html.erb
+++ b/app/views/shopping_carts/close.html.erb
@@ -69,9 +69,9 @@
         <p>Endereço de Entrega</p>
         <%= form_with model: @order , data: {turbo: false} do |f| %>
           <div>
-            <%= collection_radio_buttons(:order, :address_id, @addresses, :id, :full_description) do |b| %>
+            <% @addresses.each do |address| %>
               <div class="form-check">
-                <%= b.label(class: 'form-check-label') { b.radio_button(class: "form-check-input") + b.text} %>
+                <%= radio_button_tag :address_id,  address.id, address.full_description %>
               </div>
             <% end %>
 

--- a/app/views/shopping_carts/close.html.erb
+++ b/app/views/shopping_carts/close.html.erb
@@ -1,6 +1,7 @@
 <div class="m-3">
   <div class="m-lg-3 p-3 border shadow">
     <h2 class="mb-4 text-center">Finalize seu Pedido</h2>
+
     <div>
       <h3>Meus Dados</h3>
       <div class="border p-3">
@@ -10,16 +11,7 @@
         <p>Telefone: <%= current_user.formatted_phone %></p>
       </div>
     </div>
-    <div>
-      <h3 class="mt-3">Endereço de entrega</h3>
-      <div class="border p-3">
-        <p>Destinarário: <%= current_user.name %></p>
-        <% unless @default_address.nil? %>
-          <p><%= @default_address.address %>, <%= @default_address.number %></p>
-          <p><%= @default_address.zipcode %> - <%= @default_address.city %> / <%= @default_address.state %></p>
-        <% end %>
-      </div>
-    </div>
+
     <div>
       <h3 class="mt-3">Itens da Compra</h3>
       <div class="border p-3">
@@ -50,43 +42,59 @@
         </table>
       </div>
     </div>
+
     <div>
       <h3 class="mt-3">Pagamento</h3>
+
       <div class="border p-3">
-      <table class="table table-striped table-hover mt-4 ">
-        <thead>
-          <tr class="text-center">
-            <th>Subtotal</th>
-            <th>Desconto</th>
-            <th>Total do Pedido</th>
-          </tr>
-        </thead>
-        <tbody class="table-group-divider">
-            <div>
-              <tr class="text-center">
-                <td><%= price_in_points(@shopping_cart.total.round) %> Pontos</td>
-                <td><%= price_in_points(@shopping_cart.total.round - total_cart(@shopping_cart, @company)) %> Pontos</td>
-                <td><%= price_in_points(total_cart(@shopping_cart, @company)) %> Pontos</td>
-              </tr>
-            </div>
-        </tbody>
-      </table>
-        <div class="border p-3 mt-3">
-          <%= form_with url: close_order_path, data: {turbo: false}, method: :post do |f| %>
-            <div class="d-flex gap-3">
-              <div>
-                <%= f.label :card_number, 'Número do Cartão', class:'form-label mt-1' %>
-              </div>
-              <div>
-                <%= f.text_field :card_number, class:'form-control' %>
-              </div>
-              <div>
-                <%= f.submit 'Concluir compra', class:'btn btn-secondary' %>
-              </div>
-            </div>
-          <% end %>
-        </div>
+        <table class="table table-striped table-hover mt-4 ">
+          <thead>
+            <tr class="text-center">
+              <th>Subtotal</th>
+              <th>Desconto</th>
+              <th>Total do Pedido</th>
+            </tr>
+          </thead>
+          <tbody class="table-group-divider">
+            <tr class="text-center">
+              <td><%= price_in_points(@shopping_cart.total.round) %> Pontos</td>
+              <td><%= price_in_points(@shopping_cart.total.round - total_with_discount_cart(@shopping_cart, @company)) %> Pontos</td>
+              <td><%= price_in_points(total_with_discount_cart(@shopping_cart, @company)) %> Pontos</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
+
+      <div class="border p-3 mt-3">
+        <p>Endereço de Entrega</p>
+        <%= form_with model: @order , data: {turbo: false} do |f| %>
+          <div>
+            <%= collection_radio_buttons(:order, :address_id, @addresses, :id, :full_description) do |b| %>
+              <div class="form-check">
+                <%= b.label(class: 'form-check-label') { b.radio_button(class: "form-check-input") + b.text} %>
+              </div>
+            <% end %>
+
+            <% if @addresses.empty? %>
+              <p> Nenhum endereço cadastrado </p>
+              <%= link_to 'Cadastrar Endereço', new_address_path, class: 'btn btn-secondary' %>
+            <% end %>
+          </div>
+
+          <div class="d-flex gap-3">
+            <div>
+              <%= f.label :card_number, 'Número do Cartão', class:'form-label mt-1' %>
+            </div>
+            <div>
+              <%= f.text_field :card_number, class:'form-control' %>
+            </div>
+            <div>
+              <%= f.submit 'Concluir compra', class:'btn btn-primary' %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
     </div>
   </div>
 </div>

--- a/app/views/shopping_carts/close.html.erb
+++ b/app/views/shopping_carts/close.html.erb
@@ -18,7 +18,6 @@
           <p><%= @default_address.address %>, <%= @default_address.number %></p>
           <p><%= @default_address.zipcode %> - <%= @default_address.city %> / <%= @default_address.state %></p>
         <% end %>
-        <%= render 'addresses_list', user: current_user %>
       </div>
     </div>
     <div>

--- a/config/locales/order.pt-BR.yml
+++ b/config/locales/order.pt-BR.yml
@@ -19,9 +19,9 @@ pt-BR:
     create:
       success: 'Pedido criado com sucesso.'
       error: 'Pedido cancelado.'
-    close_order:
       card_number_empty: 'Campo Número do Cartão não pode ser vazio.'
       connection_error: 'Erro de conexão - tente novamente mais tarde.'
       card_number_length_invalid: 'Número de cartão precisar ter 11 dígitos.'
       card_not_present: 'Erro de conexão - por favor, faça login novamente.'
       success: 'Pedido criado com sucesso.'
+      address_required: 'Não é possível finalizar pedido sem endereço cadastrado!'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,8 +46,7 @@ Rails.application.routes.draw do
     get "close", on: :collection
   end
 
-  resources :orders, only: [:index, :show]
-  post "close_order", to: "orders#close_order"
+  resources :orders, only: [:index, :show, :create]
 
   get "me", to: "customer_areas#me"
   get "client_addresses", to: "customer_areas#addresses"

--- a/db/migrate/20230702225142_add_address_to_orders.rb
+++ b/db/migrate/20230702225142_add_address_to_orders.rb
@@ -1,0 +1,5 @@
+class AddAddressToOrders < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :orders, :address, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20230703142743_create_order_addresses.rb
+++ b/db/migrate/20230703142743_create_order_addresses.rb
@@ -1,0 +1,14 @@
+class CreateOrderAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :order_addresses do |t|
+      t.references :order, null: false, foreign_key: true
+      t.string :address
+      t.string :number
+      t.string :city
+      t.string :state
+      t.string :zipcode
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230703153433_remove_address_from_order.rb
+++ b/db/migrate/20230703153433_remove_address_from_order.rb
@@ -1,0 +1,5 @@
+class RemoveAddressFromOrder < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :orders, :address, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_02_225142) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_03_153433) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_02_225142) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -113,6 +113,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_02_225142) do
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
+  create_table "order_addresses", force: :cascade do |t|
+    t.integer "order_id", null: false
+    t.string "address"
+    t.string "number"
+    t.string "city"
+    t.string "state"
+    t.string "zipcode"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_addresses_on_order_id"
+  end
+
   create_table "order_items", force: :cascade do |t|
     t.integer "order_id", null: false
     t.integer "product_id", null: false
@@ -145,8 +157,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_02_225142) do
     t.float "conversion_tax"
     t.integer "status", default: 0
     t.string "payment_code"
-    t.integer "address_id", null: false
-    t.index ["address_id"], name: "index_orders_on_address_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -226,11 +236,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_02_225142) do
   add_foreign_key "client_addresses", "users"
   add_foreign_key "favorites", "products"
   add_foreign_key "favorites", "users"
+  add_foreign_key "order_addresses", "orders"
   add_foreign_key "order_items", "orders"
   add_foreign_key "order_items", "products"
   add_foreign_key "orderables", "products"
   add_foreign_key "orderables", "shopping_carts"
-  add_foreign_key "orders", "addresses"
   add_foreign_key "orders", "users"
   add_foreign_key "product_categories", "product_categories", column: "parent_id"
   add_foreign_key "products", "product_categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_30_193159) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_02_225142) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_193159) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -145,6 +145,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_193159) do
     t.float "conversion_tax"
     t.integer "status", default: 0
     t.string "payment_code"
+    t.integer "address_id", null: false
+    t.index ["address_id"], name: "index_orders_on_address_id"
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
@@ -228,6 +230,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_193159) do
   add_foreign_key "order_items", "products"
   add_foreign_key "orderables", "products"
   add_foreign_key "orderables", "shopping_carts"
+  add_foreign_key "orders", "addresses"
   add_foreign_key "orders", "users"
   add_foreign_key "product_categories", "product_categories", column: "parent_id"
   add_foreign_key "products", "product_categories"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,8 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_153433) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_153433) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
+    t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :order_address do
+    order { create(:order) }
+    address { 'Rua Principal' }
+    number { '100' }
+    city { 'Constatinópoles' }
+    state { 'Paraisópoles' }
+    zipcode { '12345678' }
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     discount_amount { 0 }
     final_value { 1000 }
     user { create(:user) }
+    address { create(:address) }
     conversion_tax { 20 }
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     discount_amount { 0 }
     final_value { 1000 }
     user { create(:user) }
-    address { create(:address) }
     conversion_tax { 20 }
   end
 end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 RSpec.describe OrderItem, type: :model do
   describe '#valid?' do
     it 'erro com quantidade inválida' do
-      product = create(:product)
-      order = create(:order)
-
-      order_item = OrderItem.new(order:, product:, quantity: 0)
+      order_item = OrderItem.new(quantity: 0)
       result = order_item.valid?
 
       expect(result).to eq false

--- a/spec/requests/user_creates_order_request_spec.rb
+++ b/spec/requests/user_creates_order_request_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Usuário fecha pedido' do
   it 'com sucesso, autenticado e com cartão ativo' do
     user = create(:user, email: 'user@email.com', cpf: '30383993024')
+    address = create(:address)
     create(:card_info, user:, points: 50_000)
     shopping_cart = create(:shopping_cart)
     category1 = create(:product_category, name: 'Camisetas')
@@ -19,7 +20,7 @@ describe 'Usuário fecha pedido' do
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/cards/#{user.cpf}").and_return(fake_response_card)
 
     login_as(user)
-    post close_order_path params: { card_number: '12345678901234567890' }
+    post orders_path params: { order: { card_number: '12345678901234567890', address_id: address.id } }
 
     expect(response).to have_http_status :found
     expect(response).to redirect_to order_path(Order.last.id)
@@ -28,6 +29,7 @@ describe 'Usuário fecha pedido' do
 
   it 'sem sucesso, não estando autenticado' do
     user = create(:user, email: 'user@email.com', cpf: '30383993024')
+    address = create(:address)
     create(:card_info, user:, points: 5000)
     shopping_cart = create(:shopping_cart)
     category1 = create(:product_category, name: 'Camisetas')
@@ -43,7 +45,7 @@ describe 'Usuário fecha pedido' do
     fake_response_card = double('faraday_response', status: 200, body: json_data)
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/cards/#{user.cpf}").and_return(fake_response_card)
 
-    post close_order_path params: { card_number: '12345678901234567890' }
+    post orders_path params: { order: { card_number: '12345678901234567890', address_id: address.id } }
 
     expect(response).to have_http_status :found
     expect(response).to redirect_to new_user_session_path
@@ -52,6 +54,7 @@ describe 'Usuário fecha pedido' do
 
   it 'sem sucesso, não possuíndo cartão ativo no clube' do
     user = create(:user, email: 'user@email.com', cpf: '30383993024')
+    address = create(:address)
     shopping_cart = create(:shopping_cart)
     category1 = create(:product_category, name: 'Camisetas')
     product1 = create(:product, name: 'Camiseta Azul', price: 800, product_category: category1,
@@ -67,7 +70,7 @@ describe 'Usuário fecha pedido' do
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/cards/#{user.cpf}").and_return(fake_response_card)
 
     login_as(user)
-    post close_order_path params: { card_number: '12345678901234567890' }
+    post orders_path params: { order: { card_number: '12345678901234567890', address_id: address.id } }
 
     expect(response).to have_http_status :found
     expect(response).to redirect_to close_shopping_carts_path(shopping_cart.id)
@@ -76,6 +79,7 @@ describe 'Usuário fecha pedido' do
 
   it 'sem sucesso devido a API de pagamentos offline, autenticado e com cartão ativo' do
     user = create(:user, email: 'user@email.com', cpf: '30383993024')
+    address = create(:address)
     create(:card_info, user:, points: 5000)
     shopping_cart = create(:shopping_cart)
     category1 = create(:product_category, name: 'Camisetas')
@@ -88,7 +92,7 @@ describe 'Usuário fecha pedido' do
     allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/payments').and_raise(Faraday::ConnectionFailed)
 
     login_as(user)
-    post close_order_path params: { card_number: '12345678901234567890' }
+    post orders_path params: { order: { card_number: '12345678901234567890', address_id: address.id } }
 
     expect(response).to have_http_status :found
     expect(response).to redirect_to shopping_cart_path(shopping_cart)

--- a/spec/requests/user_creates_order_request_spec.rb
+++ b/spec/requests/user_creates_order_request_spec.rb
@@ -20,7 +20,7 @@ describe 'Usuário fecha pedido' do
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/cards/#{user.cpf}").and_return(fake_response_card)
 
     login_as(user)
-    post orders_path params: { order: { card_number: '12345678901234567890', address_id: address.id } }
+    post orders_path params: { order: { card_number: '12345678901234567890' }, address_id: address.id }
 
     expect(response).to have_http_status :found
     expect(response).to redirect_to order_path(Order.last.id)
@@ -92,7 +92,7 @@ describe 'Usuário fecha pedido' do
     allow(Faraday).to receive(:post).with('http://localhost:4000/api/v1/payments').and_raise(Faraday::ConnectionFailed)
 
     login_as(user)
-    post orders_path params: { order: { card_number: '12345678901234567890', address_id: address.id } }
+    post orders_path params: { order: { card_number: '12345678901234567890' }, address_id: address.id }
 
     expect(response).to have_http_status :found
     expect(response).to redirect_to shopping_cart_path(shopping_cart)

--- a/spec/system/user_creates_order_spec.rb
+++ b/spec/system/user_creates_order_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe 'Usuário logado acessa a página do carrinho' do
   it 'e finaliza pedido com sucesso' do
     user = create(:user, email: 'user@email.com', cpf: '30383993024')
+    address = create(:address)
+    create(:client_address, user:, address:, default: true)
     create(:card_info, user:, points: 999_999, conversion_tax: 20)
     shopping_cart = create(:shopping_cart)
     product_category = create(:product_category, name: 'Camisetas')
@@ -46,6 +48,8 @@ describe 'Usuário logado acessa a página do carrinho' do
 
   it 'e tenta finalizar sem informar o número cartão' do
     user = create(:user, email: 'user@email.com')
+    address = create(:address)
+    create(:client_address, user:, address:, default: true)
     create(:card_info, user:, points: 999_999, conversion_tax: 20)
     shopping_cart = create(:shopping_cart)
     product_category = create(:product_category, name: 'Camisetas')
@@ -73,6 +77,8 @@ describe 'Usuário logado acessa a página do carrinho' do
 
   it 'e pedido não finaliza por erro de conexão' do
     user = create(:user, email: 'user@email.com')
+    address = create(:address)
+    create(:client_address, user:, address:, default: true)
     create(:card_info, user:, points: 999_999, conversion_tax: 20)
     shopping_cart = create(:shopping_cart)
     product_category = create(:product_category, name: 'Camisetas')
@@ -128,8 +134,7 @@ describe 'Usuário logado acessa a página do carrinho' do
     fill_in 'Número do Cartão', with: '12345678901234567890'
     click_on 'Concluir compra'
 
-    expect(page).to have_content 'Não pode finalizar pedido sem endereço cadastrado!'
-    
+    expect(current_path).to eq shopping_cart_path(shopping_cart)
+    expect(page).to have_content 'Não é possível finalizar pedido sem endereço cadastrado!'
   end
-
 end

--- a/spec/system/user_creates_order_spec.rb
+++ b/spec/system/user_creates_order_spec.rb
@@ -102,4 +102,34 @@ describe 'Usuário logado acessa a página do carrinho' do
     expect(page).to have_content('Erro de conexão - tente novamente mais tarde.')
     expect(page).to have_content('Camiseta Azul')
   end
+
+  it 'e tenta finalizar sem endereço cadastrado' do
+    user = create(:user, email: 'user@email.com', cpf: '30383993024')
+    create(:card_info, user:, points: 999_999, conversion_tax: 20)
+    shopping_cart = create(:shopping_cart)
+    product_category = create(:product_category, name: 'Camisetas')
+    product = create(:product, name: 'Camiseta Azul', price: 800, product_category:,
+                               description: 'Uma camisa azul muito bonita', code: 'CMA123456')
+    shopping_cart.orderables.create(product:, shopping_cart:, quantity: 2)
+    session = { cart_id: shopping_cart.id }
+    allow_any_instance_of(ApplicationController).to receive(:session).and_return(session)
+    order_json_data = Rails.root.join('spec/support/json/order_with_status_pending.json').read
+    fake_response = double('faraday_response', status: 201, body: order_json_data)
+    url = 'http://localhost:4000/api/v1/payments'
+    allow(Faraday).to receive(:post).with(url).and_return(fake_response)
+    json_data = Rails.root.join('spec/support/json/card_data_active.json').read
+    fake_response_two = double('faraday_response', status: 200, body: json_data)
+    allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/cards/#{user.cpf}").and_return(fake_response_two)
+
+    visit root_path
+    login_as(user)
+    click_on 'Carrinho'
+    click_on 'Finalizar compra'
+    fill_in 'Número do Cartão', with: '12345678901234567890'
+    click_on 'Concluir compra'
+
+    expect(page).to have_content 'Não pode finalizar pedido sem endereço cadastrado!'
+    
+  end
+
 end

--- a/spec/system/user_register_new_address_spec.rb
+++ b/spec/system/user_register_new_address_spec.rb
@@ -19,7 +19,7 @@ describe 'Usuário registra um novo endereço' do
     expect(page).to have_button 'Salvar endereço'
   end
 
-  it 'com sucesso' do
+  it 'com sucesso, e se torna padrão caso seja o primeiro cadastrado' do
     user = create(:user)
 
     login_as(user)
@@ -32,6 +32,31 @@ describe 'Usuário registra um novo endereço' do
     click_on 'Salvar endereço'
 
     expect(current_path).to eq client_addresses_path
+    expect(page).not_to have_button 'Selecionar como Padrão'
+    expect(ClientAddress.last.default).to eq true
+    expect(page).to have_content 'Rua Dr. Alcides Pereira, 111'
+    expect(page).to have_content 'Maruim'
+    expect(page).to have_content 'Sergipe'
+    expect(page).to have_content '49770000'
+  end
+
+  it 'com sucesso, e não se torna padrão caso já tenha endereço cadastrado' do
+    user = create(:user)
+    address = create(:address)
+    ClientAddress.create!(user:, address:)
+
+    login_as(user)
+    visit new_address_path
+    fill_in 'Endereço', with: 'Rua Dr. Alcides Pereira'
+    fill_in 'Número', with: '111'
+    fill_in 'Cidade', with: 'Maruim'
+    fill_in 'Estado', with: 'Sergipe'
+    fill_in 'CEP', with: '49770000'
+    click_on 'Salvar endereço'
+
+    expect(current_path).to eq client_addresses_path
+    expect(page).to have_button 'Selecionar como Padrão'
+    expect(ClientAddress.last.default).to eq false
     expect(page).to have_content 'Rua Dr. Alcides Pereira, 111'
     expect(page).to have_content 'Maruim'
     expect(page).to have_content 'Sergipe'

--- a/spec/system/user_visit_order_history_spec.rb
+++ b/spec/system/user_visit_order_history_spec.rb
@@ -30,9 +30,8 @@ describe 'Usuário acessa histórico de pedidos' do
 
   it 'com sucesso e o status do pedido é atualizado quando necessário' do
     user = create(:user)
-    address = create(:address)
-    create(:client_address, user:, address:, default: true)
-    order = create(:order, user:, address:, status: 'pending', payment_code: 'KRYZSMPPGA')
+    order = create(:order, user:, status: 'pending', payment_code: 'KRYZSMPPGA')
+    create(:order_address, order:)
     order_json_data = Rails.root.join('spec/support/json/order_with_status_approved.json').read
     fake_response = double('faraday_response', status: 201, body: order_json_data)
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/payments/#{order.payment_code}").and_return(fake_response)
@@ -46,9 +45,8 @@ describe 'Usuário acessa histórico de pedidos' do
 
   it 'com sucesso, mas o status do pedido não é atualizado, pois a API de cartões está fora' do
     user = create(:user)
-    address = create(:address)
-    create(:client_address, user:, address:, default: true)
-    order = create(:order, user:, address:, status: 'pending', payment_code: 'KRYZSMPPGA')
+    order = create(:order, user:, status: 'pending', payment_code: 'KRYZSMPPGA')
+    create(:order_address, order:)
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/payments/#{order.payment_code}").and_raise(Faraday::ConnectionFailed)
 
     login_as user

--- a/spec/system/user_visit_order_history_spec.rb
+++ b/spec/system/user_visit_order_history_spec.rb
@@ -30,7 +30,9 @@ describe 'Usuário acessa histórico de pedidos' do
 
   it 'com sucesso e o status do pedido é atualizado quando necessário' do
     user = create(:user)
-    order = create(:order, user:, status: 'pending')
+    address = create(:address)
+    create(:client_address, user:, address:, default: true)
+    order = create(:order, user:, address:, status: 'pending', payment_code: 'KRYZSMPPGA')
     order_json_data = Rails.root.join('spec/support/json/order_with_status_approved.json').read
     fake_response = double('faraday_response', status: 201, body: order_json_data)
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/payments/#{order.payment_code}").and_return(fake_response)
@@ -44,7 +46,9 @@ describe 'Usuário acessa histórico de pedidos' do
 
   it 'com sucesso, mas o status do pedido não é atualizado, pois a API de cartões está fora' do
     user = create(:user)
-    order = create(:order, user:, status: 'pending')
+    address = create(:address)
+    create(:client_address, user:, address:, default: true)
+    order = create(:order, user:, address:, status: 'pending', payment_code: 'KRYZSMPPGA')
     allow(Faraday).to receive(:get).with("http://localhost:4000/api/v1/payments/#{order.payment_code}").and_raise(Faraday::ConnectionFailed)
 
     login_as user


### PR DESCRIPTION
Esta PR modifica o comportamento do endereço padrão do usuário: ao cadastrar o primeiro endereço este é automaticamente definido como padrão e opcionalmente o usuário pode selecionar outro na área do cliente.

Agora os endereços também passam a estar atrelados aos pedidos e são necessários para concluir uma compra.

Close #91 