### PR TITLE
Corrigido imagem de meus pedidos aparece quando produto não tem imagem

### DIFF
--- a/app/views/customer_areas/order_history.html.erb
+++ b/app/views/customer_areas/order_history.html.erb
@@ -41,7 +41,11 @@
               <div class='d-flex align-items-center justify-content-between text-center'>
                 <div class='d-flex flex-column'>
                   <%= link_to product_path(product) do %>
-                    <%= image_tag product.product_images[0], loading: 'lazy', class: 'order-details-img'%>
+                    <% if product.product_images.any? %>
+                      <%= image_tag product.product_images[0], loading: 'lazy', class: 'order-details-img'%>
+                    <% else %>
+                      <%= image_tag(asset_path('no_image.jpg'), alt:product.name, class:"card-img-top card-image")%>
+                    <% end %>
                   <% end %>
                 </div>
                 <div class='d-flex flex-column' style="min-width: 200px;">


### PR DESCRIPTION
# Esse PR corrige 
## Erro da view quebrar ao visualizar pedido com produto sem imagem

![corrigido](https://github.com/TreinaDev/LojaClubeTD10/assets/92684440/285ad1e7-e1c9-49de-b26b-dc65edd326ca)
